### PR TITLE
Fix xeus-octave in mac

### DIFF
--- a/src/toolkits/opengl.hpp
+++ b/src/toolkits/opengl.hpp
@@ -22,10 +22,15 @@
 // <https://www.gnu.org/licenses/>.
 //
 ////////////////////////////////////////////////////////////////////////
-
+#if defined(__APPLE__)
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+#include <OpenGL/glext.h>
+#else
 #include <GL/gl.h>
 #include <GL/glext.h>
 #include <GL/glu.h>
+#endif
 
 #include <iostream>
 


### PR DESCRIPTION
Hey @rapgenic, I was testing `xeus-octave` in Mac and I noticed it use different imports, so I added it here! :)
