### PR TITLE
Fix warning: 'graphics_object' is deprecated: [7]: use 'octave::graphics_object'

### DIFF
--- a/src/toolkits/notebook.cpp
+++ b/src/toolkits/notebook.cpp
@@ -97,10 +97,10 @@ notebook_graphics_toolkit::~notebook_graphics_toolkit() {
 	glfwTerminate();
 }
 
-bool notebook_graphics_toolkit::initialize(const graphics_object& go) {
+bool notebook_graphics_toolkit::initialize(const octave::graphics_object& go) {
 	if (go.isa("figure")) {
 		// Set the pixel ratio
-		figure::properties& figureProperties = dynamic_cast<figure::properties&>(graphics_object(go).get_properties());
+		figure::properties& figureProperties = dynamic_cast<figure::properties&>(octave::graphics_object(go).get_properties());
 		float xscale, yscale;
 
 		if (auto* monitor = glfwGetPrimaryMonitor())
@@ -125,10 +125,10 @@ bool notebook_graphics_toolkit::initialize(const graphics_object& go) {
 	return false;
 }
 
-void notebook_graphics_toolkit::finalize(const graphics_object&) {
+void notebook_graphics_toolkit::finalize(const octave::graphics_object&) {
 }
 
-void notebook_graphics_toolkit::show_figure(const graphics_object& go) const {
+void notebook_graphics_toolkit::show_figure(const octave::graphics_object& go) const {
 	int id = getPlotStream(go);
 
 	json tran;
@@ -136,14 +136,14 @@ void notebook_graphics_toolkit::show_figure(const graphics_object& go) const {
 	dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter()).display_data(json::object(), json::object(), tran);
 }
 
-void notebook_graphics_toolkit::redraw_figure(const graphics_object& go) const {
+void notebook_graphics_toolkit::redraw_figure(const octave::graphics_object& go) const {
 #ifndef NDEBUG
 	std::clog << "------------" << std::endl;
 	auto start = high_resolution_clock::now();
 #endif
 
 	int id = getPlotStream(go);
-	figure::properties& figureProperties = dynamic_cast<figure::properties&>(graphics_object(go).get_properties());
+	figure::properties& figureProperties = dynamic_cast<figure::properties&>(octave::graphics_object(go).get_properties());
 	Matrix figurePosition = figureProperties.get_position().matrix_value();
 
 	double dpr = figureProperties.get___device_pixel_ratio__();
@@ -246,7 +246,7 @@ void notebook_graphics_toolkit::redraw_figure(const graphics_object& go) const {
 #endif
 }
 
-void notebook_graphics_toolkit::update(const graphics_object&, int) {
+void notebook_graphics_toolkit::update(const octave::graphics_object&, int) {
 }
 
 }  // namespace xoctave

--- a/src/toolkits/notebook.hpp
+++ b/src/toolkits/notebook.hpp
@@ -43,12 +43,12 @@ public:
 
 	bool is_valid() const override { return true; }
 
-	bool initialize(const graphics_object &) override;
-	void redraw_figure(const graphics_object &) const override;
-	void show_figure(const graphics_object &) const override;
-	void update(const graphics_object &, int) override;
+	bool initialize(const octave::graphics_object &) override;
+	void redraw_figure(const octave::graphics_object &) const override;
+	void show_figure(const octave::graphics_object &) const override;
+	void update(const octave::graphics_object &, int) override;
 
-	void finalize(const graphics_object &) override;
+	void finalize(const octave::graphics_object &) override;
 
 private:
 #ifndef NOTEBOOK_TOOLKIT_CPU

--- a/src/toolkits/plotly.cpp
+++ b/src/toolkits/plotly.cpp
@@ -44,7 +44,7 @@
 
 namespace xoctave {
 
-bool plotly_graphics_toolkit::initialize(const graphics_object& go) {
+bool plotly_graphics_toolkit::initialize(const octave::graphics_object& go) {
 	if (go.isa("figure")) {
 		setPlotStream(go, rand());
 		show_figure(go);
@@ -55,12 +55,12 @@ bool plotly_graphics_toolkit::initialize(const graphics_object& go) {
 	return false;
 }
 
-void plotly_graphics_toolkit::redraw_figure(const graphics_object& go) const {
+void plotly_graphics_toolkit::redraw_figure(const octave::graphics_object& go) const {
 	int id = getPlotStream(go);
 
 	if (go.isa("figure")) {
 		std::map<std::string, std::vector<unsigned long>> ids;
-		figure::properties& figureProperties = dynamic_cast<figure::properties&>(graphics_object(go).get_properties());
+		figure::properties& figureProperties = dynamic_cast<figure::properties&>(octave::graphics_object(go).get_properties());
 		Matrix figurePosition = figureProperties.get_position().matrix_value();
 		json plot, output;
 
@@ -89,13 +89,13 @@ void plotly_graphics_toolkit::redraw_figure(const graphics_object& go) const {
 			if (ax.isa("axes")) {
 				axes::properties& axisProperties = dynamic_cast<axes::properties&>(ax.get_properties());
 #if OCTAVE_MAJOR_VERSION >= 6
-				graphics_object xlabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_xlabel());
-				graphics_object ylabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_ylabel());
-				graphics_object zlabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_ylabel());
+				octave::graphics_object xlabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_xlabel());
+				octave::graphics_object ylabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_ylabel());
+				octave::graphics_object zlabel = m_interpreter.get_gh_manager().get_object(axisProperties.get_ylabel());
 #else
-				graphics_object xlabel = gh_manager::get_object(axisProperties.get_xlabel());
-				graphics_object ylabel = gh_manager::get_object(axisProperties.get_ylabel());
-				graphics_object zlabel = gh_manager::get_object(axisProperties.get_ylabel());
+				octave::graphics_object xlabel = gh_manager::get_object(axisProperties.get_xlabel());
+				octave::graphics_object ylabel = gh_manager::get_object(axisProperties.get_ylabel());
+				octave::graphics_object zlabel = gh_manager::get_object(axisProperties.get_ylabel());
 #endif
 
 				text::properties& xlabelProperties = dynamic_cast<text::properties&>(xlabel.get_properties());
@@ -456,7 +456,7 @@ void plotly_graphics_toolkit::redraw_figure(const graphics_object& go) const {
 	}
 }
 
-void plotly_graphics_toolkit::show_figure(const graphics_object& go) const {
+void plotly_graphics_toolkit::show_figure(const octave::graphics_object& go) const {
 	int id = getPlotStream(go);
 
 	json tran;
@@ -464,10 +464,10 @@ void plotly_graphics_toolkit::show_figure(const graphics_object& go) const {
 	dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter()).display_data(json::object(), json::object(), tran);
 }
 
-std::vector<graphics_object> plotly_graphics_toolkit::children(const graphics_object& go, bool all) const {
+std::vector<octave::graphics_object> plotly_graphics_toolkit::children(const octave::graphics_object& go, bool all) const {
 	Matrix c = all ? go.get_properties().get_all_children() : go.get_properties().get_children();
 	int len = c.numel();
-	std::vector<graphics_object> ret;
+	std::vector<octave::graphics_object> ret;
 
 	for (int i = len - 1; i >= 0; i--) {
 		ret.push_back(m_interpreter.get_gh_manager().get_object(c(i)));

--- a/src/toolkits/plotly.hpp
+++ b/src/toolkits/plotly.hpp
@@ -50,9 +50,9 @@ public:
 
 	bool is_valid() const override { return true; }
 
-	bool initialize(const graphics_object& go) override;
-	void redraw_figure(const graphics_object& go) const override;
-	void show_figure(const graphics_object& go) const override;
+	bool initialize(const octave::graphics_object& go) override;
+	void redraw_figure(const octave::graphics_object& go) const override;
+	void show_figure(const octave::graphics_object& go) const override;
 
 private:
 	/**
@@ -60,7 +60,7 @@ private:
 	 * polar), when more than one is present. The suffix for the first one is
 	 * always "" (empty), then 1,2,3...
 	 */
-	inline std::string getObjectNumber(const graphics_object& o, std::map<std::string, std::vector<unsigned long>>& ids) const {
+	inline std::string getObjectNumber(const octave::graphics_object& o, std::map<std::string, std::vector<unsigned long>>& ids) const {
 		double h = o.get_handle().value();
 		unsigned long id = *(unsigned long*) &h;
 		std::string type;
@@ -99,9 +99,9 @@ private:
 	}
 
 	/**
-	 * Get a vector of all the children of the @go graphics_object
+	 * Get a vector of all the children of the @go octave::graphics_object
 	 */
-	std::vector<graphics_object> children(const graphics_object& go, bool all = false) const;
+	std::vector<octave::graphics_object> children(const octave::graphics_object& go, bool all = false) const;
 
 	/**
 	 * Convert an octave color matrix to a css rgb string

--- a/src/toolkits/plotstream.hpp
+++ b/src/toolkits/plotstream.hpp
@@ -24,18 +24,18 @@
 
 namespace xoctave {
 
-inline int getPlotStream(const graphics_object& o) {
+inline int getPlotStream(const octave::graphics_object& o) {
 	return dynamic_cast<const figure::properties&>(o.get_ancestor("figure").get_properties())
 		.get___plot_stream__()
 		.int_value();
 }
 
-inline void setPlotStream(graphics_object& o, int p) {
+inline void setPlotStream(octave::graphics_object& o, int p) {
 	if (o.isa("figure"))
 		dynamic_cast<figure::properties&>(o.get_properties()).set___plot_stream__(p);
 }
 
-inline void setPlotStream(const graphics_object& o, int p) {
+inline void setPlotStream(const octave::graphics_object& o, int p) {
 	// deCONSTify the graphics_object
 	auto _go = o;
 	setPlotStream(_go, p);


### PR DESCRIPTION
With octave 7.0, `graphics_object` is deprecated and we should use `octave::graphics_object`.