### PR TITLE
Add GLAD loader and remove osmesa

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,11 +27,11 @@ jobs:
           environment-name: xeus-octave
           cache-downloads: true
       - name: Configure
-        run: cmake --preset conda-debug-osmesa
+        run: cmake --preset conda-debug
       - name: Build
-        run: cmake --build --preset conda-debug-osmesa
+        run: cmake --build --preset conda-debug
       - name: Install
-        run: cmake --install build/cmake/conda-debug-osmesa
+        run: cmake --install build/cmake/conda-debug
       - name: Test
         run: python -m pytest ./test -k 'not plot'
       - name: Plotly toolkit test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,8 +221,7 @@ macro(xeus_octave_create_target target_name linkage output_name)
     target_compile_definitions(
         ${target_name}
         PUBLIC "XEUS_OCTAVE_EXPORTS"
-        PRIVATE XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED
-                XEUS_OCTAVE_OVERRIDE_PATH="${CMAKE_INSTALL_PREFIX}/share/xeus-octave"
+        PRIVATE XEUS_OCTAVE_OVERRIDE_PATH="${CMAKE_INSTALL_PREFIX}/share/xeus-octave"
     )
     target_compile_features(${target_name} PRIVATE cxx_std_17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,15 +82,11 @@ if(NOT TARGET xeus AND NOT TARGET xeus-static)
 endif()
 
 find_package(PNG REQUIRED)
+find_package(glad REQUIRED)
 find_package(glfw3)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(octinterp REQUIRED IMPORTED_TARGET GLOBAL octinterp)
-if(XEUS_OCTAVE_GLFW3_OSMESA_BACKEND)
-    pkg_check_modules(osmesa REQUIRED IMPORTED_TARGET osmesa)
-else()
-    find_package(OpenGL REQUIRED)
-endif()
 
 # Flags =====
 include(CheckCXXCompilerFlag)
@@ -238,19 +234,12 @@ macro(xeus_octave_create_target target_name linkage output_name)
     target_link_libraries(
         ${target_name}
         PUBLIC xtl PkgConfig::octinterp
-        PRIVATE glfw PNG::PNG
+        PRIVATE glad::glad glfw PNG::PNG
     )
     if(XEUS_OCTAVE_USE_SHARED_XEUS)
         target_link_libraries(${target_name} PUBLIC xeus)
     else()
         target_link_libraries(${target_name} PUBLIC xeus-static)
-    endif()
-
-    if(XEUS_OCTAVE_GLFW3_OSMESA_BACKEND)
-        target_link_libraries(${target_name} PRIVATE PkgConfig::osmesa)
-        target_compile_definitions(${target_name} PRIVATE XEUS_OCTAVE_GLFW3_OSMESA_BACKEND)
-    else()
-        target_link_libraries(${target_name} PRIVATE OpenGL::GL)
     endif()
 
     if(WIN32 OR CYGWIN)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,8 +2,8 @@
   "version": 2,
   "buildPresets": [
     {
-      "configurePreset": "conda-debug-osmesa",
-      "name": "conda-debug-osmesa"
+      "configurePreset": "conda-debug",
+      "name": "conda-debug"
     }
   ],
   "configurePresets": [
@@ -28,15 +28,14 @@
     },
     {
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "XEUS_OCTAVE_GLFW3_OSMESA_BACKEND": "ON"
+        "CMAKE_BUILD_TYPE": "Debug"
       },
-      "description": "A debug build using conda librarie and OSMesa",
-      "displayName": "Conda Debug OSMesa",
+      "description": "A debug build using conda libraries",
+      "displayName": "Conda Debug",
       "inherits": [
         "conda-dev"
       ],
-      "name": "conda-debug-osmesa"
+      "name": "conda-debug"
     }
   ]
 }

--- a/docs/source/dev-build-options.rst
+++ b/docs/source/dev-build-options.rst
@@ -22,13 +22,10 @@ Xeus-octave must link with xeus dynamically or statically.
 - ``XEUS_OCTAVE_USE_SHARED_XEUS``: Link with the xeus shared library (instead of the static library).
   **Enabled by default**.
 
-Octave uses OpenGL for rendering, which means that it needs a display server to render figures.
-In order to work on headless systems (e.g. servers) Xeus-Octave supports linking against glfw
-with osmesa backend (a software based OpenGL implementation).
-For this set the ``XEUS_OCTAVE_GLFW3_OSMESA_BACKEND`` CMake variable to ``ON``.
-
-Usually distributions do not provide glfw with the osmesa backend, so it's probably best to build
-glfw in-tree.
+*Xeus-Octave* uses OpenGL for rendering, which is dynamically loaded by `GLAD <https://github.com/Dav1dde/glad>`_.
+Systems without graphic cards need to use a software implementation of OpenGL.
+*Xeus-Octave* also require a display server to render figures.
+Headless systems (without a display server) may run the kernel through ``xvfb-run``.
 
 Running the Tests
 ~~~~~~~~~~~~~~~~~

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,6 +14,7 @@ dependencies:
   - nlohmann_json
   - cppzmq
   - octave =7.*
+  - glad
   - glfw
   - mesalib
   - libpng
@@ -34,3 +35,4 @@ dependencies:
   - clang
   - ccache
   - cmake-format
+  - nodejs

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -16,7 +16,6 @@ dependencies:
   - octave =7.*
   - glad
   - glfw
-  - mesalib
   - libpng
   # Test dependencies
   - pre-commit

--- a/src/toolkits/notebook.cpp
+++ b/src/toolkits/notebook.cpp
@@ -83,6 +83,8 @@ notebook_graphics_toolkit::notebook_graphics_toolkit() : base_graphics_toolkit("
 
 #ifndef NDEBUG
   std::clog << "OpenGL vendor: " << glGetString(GL_VENDOR) << '\n';
+  std::clog << "OpenGL renderer: " << glGetString(GL_RENDERER) << '\n';
+  std::clog << "OpenGL version: " << glGetString(GL_VERSION) << '\n';
 #endif
 
   glfwDestroyWindow(window);

--- a/src/toolkits/notebook.cpp
+++ b/src/toolkits/notebook.cpp
@@ -17,8 +17,6 @@
  * along with xeus-octave.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#if defined(XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED)
-
 #include <algorithm>
 #include <chrono>
 #include <cmath>
@@ -81,7 +79,7 @@ notebook_graphics_toolkit::notebook_graphics_toolkit() : base_graphics_toolkit("
 
   glfwMakeContextCurrent(window);
 
-  gladLoadGLLoader((GLADloadproc)glfwGetProcAddress);
+  gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress));
 
 #ifndef NDEBUG
   std::clog << "OpenGL vendor: " << glGetString(GL_VENDOR) << '\n';
@@ -296,5 +294,3 @@ void notebook_graphics_toolkit::update(oc::graphics_object const&, int)
 }
 
 }  // namespace xeus_octave
-
-#endif

--- a/src/toolkits/notebook.hpp
+++ b/src/toolkits/notebook.hpp
@@ -20,8 +20,6 @@
 #ifndef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_H
 #define XEUS_OCTAVE_NOTEBOOK_TOOLKIT_H
 
-#ifdef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED
-
 #include <octave/graphics-toolkit.h>
 #include <octave/interpreter.h>
 
@@ -48,7 +46,5 @@ public:
 };
 
 }  // namespace xeus_octave
-
-#endif
 
 #endif  // XEUS_OCTAVE_NOTEBOOK_TOOLKIT_H

--- a/src/toolkits/notebook.hpp
+++ b/src/toolkits/notebook.hpp
@@ -27,8 +27,6 @@
 
 #include "xeus-octave/config.hpp"
 
-typedef struct GLFWwindow GLFWwindow;
-
 namespace xeus_octave
 {
 
@@ -36,7 +34,7 @@ class notebook_graphics_toolkit : public octave::base_graphics_toolkit
 {
 public:
 
-  notebook_graphics_toolkit(octave::interpreter&);
+  notebook_graphics_toolkit();
   ~notebook_graphics_toolkit();
 
   bool is_valid() const override { return true; }
@@ -47,13 +45,6 @@ public:
   void update(octave::graphics_object const&, int) override;
 
   void finalize(octave::graphics_object const&) override;
-
-private:
-
-#ifndef XEUS_OCTAVE_GLFW3_OSMESA_BACKEND
-  GLFWwindow* window = nullptr;
-#endif
-  octave::interpreter& m_interpreter;
 };
 
 }  // namespace xeus_octave

--- a/src/toolkits/opengl.hpp
+++ b/src/toolkits/opengl.hpp
@@ -26,17 +26,7 @@
 #ifndef XEUS_OCTAVE_OPENGL_H
 #define XEUS_OCTAVE_OPENGL_H
 
-#if defined(__APPLE__)
-#include <OpenGL/gl.h>
-#include <OpenGL/glext.h>
-#include <OpenGL/glu.h>
-#else
-#include <GL/gl.h>
-#include <GL/glext.h>
-#include <GL/glu.h>
-#endif
-
-#include <iostream>
+#include <glad/glad.h>
 
 namespace octave
 {

--- a/src/toolkits/plotly.cpp
+++ b/src/toolkits/plotly.cpp
@@ -52,7 +52,8 @@ bool plotly_graphics_toolkit::initialize(oc::graphics_object const& go)
 {
   if (go.isa("figure"))
   {
-    setPlotStream(go, rand());
+    // Create a new object id and store it in the figure
+    setPlotStream(go, xeus::new_xguid());
     show_figure(go);
 
     return true;
@@ -63,7 +64,8 @@ bool plotly_graphics_toolkit::initialize(oc::graphics_object const& go)
 
 void plotly_graphics_toolkit::redraw_figure(oc::graphics_object const& go) const
 {
-  int id = getPlotStream(go);
+  // Retrieve the figure id
+  std::string id = getPlotStream(go);
 
   if (go.isa("figure"))
   {
@@ -512,23 +514,24 @@ void plotly_graphics_toolkit::redraw_figure(oc::graphics_object const& go) const
       }
     // Show the newly created plot
 
-    nl::json data, tran;
-
-    data["application/vnd.plotly.v1+json"] = plot;
-    tran["display_id"] = id;
-
-    dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter()).update_display_data(data, nl::json::object(), tran);
+    dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter())
+      .update_display_data(
+        {{"application/vnd.plotly.v1+json", plot}}, nl::json(nl::json::value_t::object), {{"display_id", id}}
+      );
   }
 }
 
 void plotly_graphics_toolkit::show_figure(oc::graphics_object const& go) const
 {
-  int id = getPlotStream(go);
+  // Get an unique identifier for this object, to be used as a display id
+  // in the display_data request for subsequent updates of the plot
+  std::string id = getPlotStream(go);
 
-  nl::json tran;
-  tran["display_id"] = id;
+  // Display an empty figure (this is equivalent to the action of creating)
+  // a window, and prepares a display with the correct display_id for
+  // future updates
   dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter())
-    .display_data(nl::json::object(), nl::json::object(), tran);
+    .display_data(nl::json(nl::json::value_t::object), nl::json(nl::json::value_t::object), {{"display_id", id}});
 }
 
 std::string plotly_graphics_toolkit::getObjectNumber(

--- a/src/toolkits/plotly.cpp
+++ b/src/toolkits/plotly.cpp
@@ -512,12 +512,12 @@ void plotly_graphics_toolkit::redraw_figure(oc::graphics_object const& go) const
           }
         }
       }
-    // Show the newly created plot
 
+    // Show the newly created plot
+    nl::json data = nl::json::object();
+    data["application/vnd.plotly.v1+json"] = std::move(plot);
     dynamic_cast<xoctave_interpreter&>(xeus::get_interpreter())
-      .update_display_data(
-        {{"application/vnd.plotly.v1+json", plot}}, nl::json(nl::json::value_t::object), {{"display_id", id}}
-      );
+      .update_display_data(std::move(data), nl::json(nl::json::value_t::object), {{"display_id", id}});
   }
 }
 

--- a/src/toolkits/plotstream.hpp
+++ b/src/toolkits/plotstream.hpp
@@ -25,20 +25,20 @@
 namespace xeus_octave
 {
 
-inline int getPlotStream(octave::graphics_object const& o)
+inline std::string getPlotStream(octave::graphics_object const& o)
 {
   return dynamic_cast<octave::figure::properties const&>(o.get_ancestor("figure").get_properties())
     .get___plot_stream__()
-    .int_value();
+    .string_value();
 }
 
-inline void setPlotStream(octave::graphics_object& o, int p)
+inline void setPlotStream(octave::graphics_object& o, std::string p)
 {
   if (o.isa("figure"))
     dynamic_cast<octave::figure::properties&>(o.get_properties()).set___plot_stream__(p);
 }
 
-inline void setPlotStream(octave::graphics_object const& o, int p)
+inline void setPlotStream(octave::graphics_object const& o, std::string p)
 {
   // deCONSTify the graphics_object
   auto _go = o;

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -157,7 +157,7 @@ std::vector<std::string> fix_traceback(std::string const& ename, std::string con
 }  // namespace
 
 nl::json xoctave_interpreter::execute_request_impl(
-  int execution_counter,
+  int /*execution_counter*/,
   std::string const& code,
   bool silent,
   bool /*store_history*/,
@@ -301,9 +301,7 @@ void xoctave_interpreter::configure_impl()
   // Register the graphics toolkits
 #ifdef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED
   interpreter.get_gtk_manager().register_toolkit("notebook");
-  interpreter.get_gtk_manager().load_toolkit(
-    octave::graphics_toolkit(new xeus_octave::notebook_graphics_toolkit(interpreter))
-  );
+  interpreter.get_gtk_manager().load_toolkit(octave::graphics_toolkit(new xeus_octave::notebook_graphics_toolkit()));
 #endif
   interpreter.get_gtk_manager().register_toolkit("plotly");
   interpreter.get_gtk_manager().load_toolkit(

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -299,10 +299,8 @@ void xoctave_interpreter::configure_impl()
   interpreter.get_output_system().page_screen_output(true);
 
   // Register the graphics toolkits
-#ifdef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED
   interpreter.get_gtk_manager().register_toolkit("notebook");
   interpreter.get_gtk_manager().load_toolkit(octave::graphics_toolkit(new xeus_octave::notebook_graphics_toolkit()));
-#endif
   interpreter.get_gtk_manager().register_toolkit("plotly");
   interpreter.get_gtk_manager().load_toolkit(
     octave::graphics_toolkit(new xeus_octave::plotly_graphics_toolkit(interpreter))
@@ -322,11 +320,7 @@ void xoctave_interpreter::configure_impl()
     output::restore(std::cerr, m_stderr);
   }
 
-#ifdef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_ENABLED
   octave::feval("graphics_toolkit", ovl("notebook"));
-#else
-  octave::feval("graphics_toolkit", ovl("plotly"));
-#endif
 
   // Register embedded functions
   xeus_octave::display::register_all(interpreter);


### PR DESCRIPTION
Hi while trying to build the project I noticed that it won't build if I'm not using osmesa, and this is probably because the conda gcc compiler cannot find the system GL libraries.

With this commit I backported from my development branch the glad (OpenGL loader) integration, so that the openGL libraries do not need to be linked at build time.

Furthermore, the Osmesa build option should no longer be necessary! I had added that only for the purpose of running the headless binder instance (which does not have a graphics card and thus no (HW) GL implementation). But with the use of xvfb (great job on that by the way!) the GL virtualisation is performed by the virtual X server in a totally transparent way and osmesa can be discarded.

In fact I've been able to run this build both in a container and locally on my PC, using either my graphics card or a totally headless setup.

On a side note, I also backported a little modification regarding the plotstream, which is now a string instead of an integer as was before. I believe that's cleaner (no need of hacky conversions between integer sizes).