### PR TITLE
Add devcontainer configuration for easy setup of the workspace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/python-3-anaconda/.devcontainer/base.Dockerfile
+
+FROM ghcr.io/mamba-org/micromamba-devcontainer:latest
+
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
+# copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
+COPY environment-dev.yml /
+RUN micromamba install -n base -f /environment-dev.yml
+
+# [Optional] Uncomment this section to install additional OS packages.
+RUN sudo apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && sudo apt-get -y install --no-install-recommends xvfb

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,37 @@
+{
+  "build": {
+    "context": "..",
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "twxs.cmake",
+        "ms-vscode.cpptools-extension-pack",
+        "mhutchie.git-graph",
+        "ms-toolsai.vscode-jupyter-powertoys"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/opt/conda/bin/python",
+        "python.formatting.autopep8Path": "/opt/conda/bin/autopep8",
+        "python.formatting.yapfPath": "/opt/conda/bin/yapf",
+        "python.linting.enabled": true,
+        "python.linting.flake8Path": "/opt/conda/bin/flake8",
+        "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
+        "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
+        "python.linting.pylintEnabled": true,
+        "python.linting.pylintPath": "/opt/conda/bin/pylint",
+        "python.terminal.activateEnvironment": false,
+        "python.testing.pytestArgs": [
+          "test"
+        ],
+        "python.testing.pytestEnabled": true,
+        "python.testing.unittestEnabled": false
+      }
+    }
+  },
+  "name": "Micromamba",
+  "remoteUser": "mambauser"
+}


### PR DESCRIPTION
I always have a lot of problems setting up conda (other than hating the idea of "polluting" my home folder/system with other packages...), and I'm quite used to devcontainers as a way to have a common and stable development environment across computers or even developers (if you are interested :-) 

This adds a simple configuration for a devcontainer environment, which inherits the micromamba devcontainer image (https://github.com/mamba-org/micromamba-devcontainer), and installs all the packages specified in the `environment-dev.yml` file, along with a few sane vscode defaults. This image uses micromamba and not conda, which I find to be much faster and much lighter on my disk space.

If you want to try it you need to run `.binder/postBuild` before running jupyter to use xvfb