### PR TITLE
[Backport 4/5]: Add more tests

### DIFF
--- a/test/octave/xtest_path.m
+++ b/test/octave/xtest_path.m
@@ -1,0 +1,2 @@
+# Check that the xeus-octave override path is the first in the path list
+assert(strcmp(strsplit(path(), pathsep()){2}, XEUS_OCTAVE_OVERRIDE_PATH))

--- a/test/test_xoctave_kernel.py
+++ b/test/test_xoctave_kernel.py
@@ -9,13 +9,16 @@
 import platform
 
 import jupyter_kernel_test
-
+import os
+from pathlib import Path
 
 class KernelTests(jupyter_kernel_test.KernelTests):
 
     kernel_name = "xoctave"
     language_name = "Octave"
     code_hello_world = "disp('hello, world')"
+    code_stderr = "fprintf(2,'this is stderr')"
+    code_generate_error = "garble"
     completion_samples = [
         {
             "text": "bessel",
@@ -41,6 +44,9 @@ class KernelTests(jupyter_kernel_test.KernelTests):
         "end\n",
     ]
     code_inspect_sample = "plot"
+    code_display_data = [
+        {'code': 'x = [0 1 2]', 'mime': 'text/html'},
+    ]
 
     def test_pager(self):
         """Reimplementation of KernelTests.code_page_something.
@@ -110,3 +116,15 @@ class KernelTests(jupyter_kernel_test.KernelTests):
         self.assertTrue(app1["layout"]["width"] > 0)
 
         self.assertEqual(content0["transient"]["display_id"], content1["transient"]["display_id"])
+
+    def test_octave_scripts(self):
+        directory = Path(__file__).parent / 'octave'
+
+        for file in directory.iterdir():
+            if file.name.endswith(".m"):
+                self.flush_channels()
+                with file.open() as script:
+                    code = script.read()
+                    reply, output_msgs = self.execute_helper(code)
+
+                    assert reply['content']['status'] == 'ok', code


### PR DESCRIPTION
This adds a few more tests, and a simple way to add some tests written directly in Octave.

Right now it loops all the files in octave folder and simply executes their content checking for an `ok` status. 

Quite basic and can be improved, but enough for now I think.