### PR TITLE
Split the notebook toolkit in two classes

### DIFF
--- a/include/xeus-octave/plotstream.hpp
+++ b/include/xeus-octave/plotstream.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Giulio Girardi.
+ * Copyright (C) 2022 Giulio Girardi.
  *
  * This file is part of xeus-octave.
  *
@@ -25,19 +25,37 @@
 namespace xeus_octave
 {
 
-inline std::string getPlotStream(octave::graphics_object const& o)
+template <class T> inline T getPlotStream(octave::graphics_object const& o);
+
+/**
+ * Retrieve from the graphics object the plot_stream property
+ */
+template <> inline std::string getPlotStream<std::string>(octave::graphics_object const& o)
 {
-  return dynamic_cast<octave::figure::properties const&>(o.get_ancestor("figure").get_properties())
-    .get___plot_stream__()
-    .string_value();
+  octave_value ps =
+    dynamic_cast<octave::figure::properties const&>(o.get_ancestor("figure").get_properties()).get___plot_stream__();
+
+  if (ps.is_string())
+    return ps.string_value();
+  else
+    return "";
 }
 
+/**
+ * Set in the graphics object the plot_stream propert
+ */
 inline void setPlotStream(octave::graphics_object& o, std::string p)
 {
   if (o.isa("figure"))
-    dynamic_cast<octave::figure::properties&>(o.get_properties()).set___plot_stream__(p);
+  {
+    auto& fp = dynamic_cast<octave::figure::properties&>(o.get_properties());
+    fp.set___plot_stream__(p);
+  }
 }
 
+/**
+ * Set in the graphics object the plot_stream propert (const version)
+ */
 inline void setPlotStream(octave::graphics_object const& o, std::string p)
 {
   // deCONSTify the graphics_object
@@ -47,4 +65,4 @@ inline void setPlotStream(octave::graphics_object const& o, std::string p)
 
 }  // namespace xeus_octave
 
-#endif  // XEUS_OCTAVE_PLOTSTREAM_H
+#endif

--- a/include/xeus-octave/tk_notebook.hpp
+++ b/include/xeus-octave/tk_notebook.hpp
@@ -20,6 +20,8 @@
 #ifndef XEUS_OCTAVE_NOTEBOOK_TOOLKIT_H
 #define XEUS_OCTAVE_NOTEBOOK_TOOLKIT_H
 
+#include <vector>
+
 #include <octave/graphics-toolkit.h>
 #include <octave/interpreter.h>
 
@@ -28,21 +30,38 @@
 namespace xeus_octave::tk::notebook
 {
 
-class notebook_graphics_toolkit : public octave::base_graphics_toolkit
+/**
+ * Generic graphics_toolkit for rendering within a GLFW context. It cannot be
+ * used on its own, but must be inherited from the actual toolkits
+ */
+class glfw_graphics_toolkit : public octave::base_graphics_toolkit
 {
 public:
 
-  notebook_graphics_toolkit();
-  ~notebook_graphics_toolkit();
+  glfw_graphics_toolkit(std::string const&);
+  ~glfw_graphics_toolkit();
+
+  bool initialize(octave::graphics_object const&) override;
+  void redraw_figure(octave::graphics_object const&) const override;
+  virtual void send_figure(octave::graphics_object const&, std::vector<char> const&, int, int, double) const = 0;
+};
+
+/**
+ * Only "user ready" toolkit. It is based on simple display_data calls. Shows
+ * an empty image on creation with a display_data call. Subsequent redraws are
+ * served by a update_display_data call.
+ */
+class notebook_graphics_toolkit : public glfw_graphics_toolkit
+{
+public:
+
+  notebook_graphics_toolkit() : glfw_graphics_toolkit("notebook") {}
 
   bool is_valid() const override { return true; }
 
   bool initialize(octave::graphics_object const&) override;
-  void redraw_figure(octave::graphics_object const&) const override;
+  void send_figure(octave::graphics_object const&, std::vector<char> const&, int, int, double) const override;
   void show_figure(octave::graphics_object const&) const override;
-  void update(octave::graphics_object const&, int) override;
-
-  void finalize(octave::graphics_object const&) override;
 };
 
 void register_all(octave::interpreter& interpreter);

--- a/src/tk_plotly.cpp
+++ b/src/tk_plotly.cpp
@@ -65,7 +65,7 @@ bool plotly_graphics_toolkit::initialize(oc::graphics_object const& go)
 void plotly_graphics_toolkit::redraw_figure(oc::graphics_object const& go) const
 {
   // Retrieve the figure id
-  std::string id = getPlotStream(go);
+  std::string id = getPlotStream<std::string>(go);
 
   if (go.isa("figure"))
   {
@@ -525,7 +525,7 @@ void plotly_graphics_toolkit::show_figure(oc::graphics_object const& go) const
 {
   // Get an unique identifier for this object, to be used as a display id
   // in the display_data request for subsequent updates of the plot
-  std::string id = getPlotStream(go);
+  std::string id = getPlotStream<std::string>(go);
 
   // Display an empty figure (this is equivalent to the action of creating)
   // a window, and prepares a display with the correct display_id for


### PR DESCRIPTION
Into one generic class (`glfw_graphics_toolkit`) for implementing a glfw based toolkit, which the main toolkit (`notebook_graphics_toolkit`) inherits.

This is useful for implementing more than one toolkits that share the same rendering process (happening in the `redraw_figure` function of the base class) but a different way of sending the data to the frontend (through the `send_figure` function).

This is part of the work for the xwidgets integration, but it's independent enough to be considered on its own.