### PR TITLE
New parsing method inspired by octave script parsing code

### DIFF
--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -316,34 +316,38 @@ nl::json xoctave_interpreter::execute_request_impl(
     {
       auto const ename = "Interrupt exception";
       auto const evalue = "Kernel was interrupted";
+      auto traceback = fix_traceback(ename, evalue);
       interpreter.recover_from_exception();
-      publish_execution_error(ename, evalue, fix_traceback(ename, evalue));
-      result = xeus::create_error_reply(ename, evalue);
+      publish_execution_error(ename, evalue, traceback);
+      result = xeus::create_error_reply(ename, evalue, traceback);
     }
     catch (oc::index_exception const& e)
     {
       auto const ename = "Index exception";
       auto evalue = e.message();
+      auto traceback = fix_traceback(ename, evalue, e.stack_trace());
       interpreter.recover_from_exception();
-      publish_execution_error(ename, evalue, fix_traceback(ename, evalue, e.stack_trace()));
-      result = xeus::create_error_reply(ename, evalue);
+      publish_execution_error(ename, evalue, traceback);
+      result = xeus::create_error_reply(ename, evalue, traceback);
     }
     catch (oc::execution_exception const& e)
     {
       auto const ename = "Execution exception";
       auto evalue = e.message();
+      auto traceback = fix_traceback(ename, evalue, e.stack_trace());
       interpreter.get_error_system().save_exception(e);
       interpreter.recover_from_exception();
-      publish_execution_error(ename, evalue, fix_traceback(ename, evalue, e.stack_trace()));
-      result = xeus::create_error_reply(ename, evalue);
+      publish_execution_error(ename, evalue, traceback);
+      result = xeus::create_error_reply(ename, evalue, traceback);
     }
     catch (std::bad_alloc const&)
     {
       auto const ename = "Memory exception";
       auto const evalue = "Could not allocate the memory required for the computation";
+      auto traceback = fix_traceback(ename, evalue);
       interpreter.recover_from_exception();
-      publish_execution_error(ename, evalue, fix_traceback(ename, evalue));
-      result = xeus::create_error_reply(ename, evalue);
+      publish_execution_error(ename, evalue, traceback);
+      result = xeus::create_error_reply(ename, evalue, traceback);
     }
   }
 

--- a/src/xinterpreter.cpp
+++ b/src/xinterpreter.cpp
@@ -251,7 +251,7 @@ nl::json xoctave_interpreter::execute_request_impl(
     {
       m_lexer.m_force_script = true;
       m_lexer.prep_for_file();
-      m_lexer.m_fcn_file_full_name = "cell[" + std::to_string(execution_counter) + "]";
+      m_lexer.m_fcn_file_name = m_lexer.m_fcn_file_full_name = "cell[" + std::to_string(execution_counter) + "]";
     }
 
     octave_value primary_fcn() { return m_primary_fcn; }

--- a/test/test_xoctave_kernel.py
+++ b/test/test_xoctave_kernel.py
@@ -117,6 +117,25 @@ class KernelTests(jupyter_kernel_test.KernelTests):
 
         self.assertEqual(content0["transient"]["display_id"], content1["transient"]["display_id"])
 
+    def test_issue_68(self):
+        """
+        This tests that parsing of code with multiple errors is actually stopped
+        on the first error
+        """
+        codes = [
+            "*+3",
+            "[][1]",
+            "undefined_symbol_1\nundefined_symbol_2"
+        ]
+
+        for code in codes:
+            self.flush_channels()
+            reply, output_msgs = self.execute_helper(code=code)
+
+            # Only the first error message should be present
+            self.assertTrue(len(output_msgs) == 1)
+            self.assertEqual(output_msgs[0]["msg_type"], "error")
+
     def test_octave_scripts(self):
         directory = Path(__file__).parent / 'octave'
 


### PR DESCRIPTION
The parser and code runner inside the execute_request implementation has been simplified.

Inspiration has been taken from the `parse_fcn_file` in `oct_parse.cc` (or `oct_parse.yy`) in Octave codebase.

The errors @AntoinePrv reported are now fixed, and the error is actually reported to the correct line of the cell.

Close: #68