### PR TITLE
Update to Octave version 8

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,8 @@
         "twxs.cmake",
         "ms-vscode.cpptools-extension-pack",
         "mhutchie.git-graph",
-        "ms-toolsai.vscode-jupyter-powertoys"
+        "ms-toolsai.vscode-jupyter-powertoys",
+        "apjanke.octave-hacking"
       ],
       "settings": {
         "python.defaultInterpreterPath": "/opt/conda/bin/python",

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -13,7 +13,7 @@ dependencies:
   - xeus-zmq =1.*
   - nlohmann_json
   - cppzmq
-  - octave =7.*
+  - octave =8.*
   - glad
   - glfw
   - libpng


### PR DESCRIPTION
This only updates the environment file. Which means that CI builds are against Octave 8, and of course manual builds (in devcontainer).
