### PR TITLE
Use GLAD2 in-tree

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       - name: Install mamba
         uses: mamba-org/provision-with-micromamba@v13
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "glad"]
+	path = glad
+	url = https://github.com/Dav1dde/glad.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,13 @@ option(
 
 find_package(xeus-zmq REQUIRED)
 find_package(PNG REQUIRED)
-find_package(glad REQUIRED)
 find_package(glfw3)
 
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(octinterp REQUIRED IMPORTED_TARGET GLOBAL octinterp)
+
+add_subdirectory(glad/cmake)
+glad_add_library(glad-static STATIC API gl:compatibility=1.1)
 
 # Flags =====
 include(CheckCXXCompilerFlag)
@@ -227,7 +229,7 @@ macro(xeus_octave_create_target target_name linkage output_name)
     target_link_libraries(
         ${target_name}
         PUBLIC xtl PkgConfig::octinterp
-        PRIVATE glad::glad glfw PNG::PNG
+        PRIVATE glfw PNG::PNG glad-static
     )
     if(XEUS_OCTAVE_USE_SHARED_XEUS)
         target_link_libraries(${target_name} PUBLIC xeus-zmq)

--- a/include/xeus-octave/opengl.hpp
+++ b/include/xeus-octave/opengl.hpp
@@ -26,7 +26,7 @@
 #ifndef XEUS_OCTAVE_OPENGL_H
 #define XEUS_OCTAVE_OPENGL_H
 
-#include <glad/glad.h>
+#include <glad/gl.h>
 
 namespace octave
 {

--- a/src/tk_notebook.cpp
+++ b/src/tk_notebook.cpp
@@ -142,7 +142,7 @@ glfw_graphics_toolkit::glfw_graphics_toolkit(std::string const& nm) : octave::ba
 
   glfwMakeContextCurrent(window);
 
-  gladLoadGLLoader(reinterpret_cast<GLADloadproc>(glfwGetProcAddress));
+  gladLoadGL(reinterpret_cast<GLADloadfunc>(glfwGetProcAddress));
 
 #ifndef NDEBUG
   std::clog << "OpenGL vendor: " << glGetString(GL_VENDOR) << '\n';


### PR DESCRIPTION
Talking to glad conda feedstock maintainer, I have found that he's not maintaining it anymore.

Plus, glad should not be used as a general purpose library but rather as a generator for opengl headers according to the needed OpenGL specification.

I've replaced the conda package with a submodule, which integrates nicely with cmake, and added the generation of OpenGL headers with compatibility for OpenGL 1.1 which seems to be what octave needs.