### PR TITLE
Fix matrix text display format

### DIFF
--- a/share/xeus-octave/display.m
+++ b/share/xeus-octave/display.m
@@ -63,7 +63,7 @@ function display(varargin)
 				case "html"
 					displaymatrixhtml(name, value, tinfo);
 				otherwise
-					displaytext(name, value);
+					displaymatrixtext(name, value);
 			end
 		case { "scalar" "complex scalar" }
 			switch fmt
@@ -88,15 +88,30 @@ function display(varargin)
 	end
 end
 
+function txt = matrixtext (name, value)
+	[~, spacing] = format;
+	compact = strcmp(spacing, 'compact');
+	if compact
+		txt = [name, ' =', newline, disp(value), newline];
+	else
+		txt = [name, ' =', newline, newline, disp(value), newline];
+	end
+end
+
 function displaymatrixhtml (name, value, fmt)
 	out.("text/html") = __matrix_to_html__(name, value, fmt);
-	out.("text/plain") = [name, " = ", disp(value)];
+	out.("text/plain") = matrixtext(name, value);
 	display_data(out);
 end
 
 function displaymatrixlatex (name, value, fmt)
 	out.("text/latex") = __matrix_to_latex__(name, value, fmt);
-	out.("text/plain") = [name, " = ", disp(value)];
+	out.("text/plain") = matrixtext(name, value);
+	display_data(out);
+end
+
+function displaymatrixtext (name, value)
+	out.("text/plain") = matrixtext(name, value);
 	display_data(out);
 end
 


### PR DESCRIPTION
Currently showing a matrix with `displayformat matrix text` gives a tight output with wrong alignment between the first row and other rows:

<img width="313" height="129" alt="image" src="https://github.com/user-attachments/assets/5566e8b4-6781-4a14-9de5-12cd4e99d49d" />

This PR reproduces the regular Octave text format:

<img width="310" height="182" alt="image" src="https://github.com/user-attachments/assets/77602833-1103-41a3-91bb-d76e04efd65a" />

It also honors the `format` setting, removing the blank line after `M =` if `format compact` is enabled.

~~I have also added an example of `displayformat matrix text` in the example notebooks, which unfortunately changed the JSON in various ways (mostly whitespace) resulting in huge diffs for these files.~~